### PR TITLE
Remove the vscode extensions field from the julia Template

### DIFF
--- a/src/julia/.devcontainer/devcontainer.json
+++ b/src/julia/.devcontainer/devcontainer.json
@@ -11,21 +11,13 @@
 		"ghcr.io/julialang/devcontainer-features/julia:1": {
 			"channel": "${templateOption:channel}"
 		}
-	},
+	}
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Configure tool-specific properties.
-	"customizations": {
-		// Additional settings for VS Code.
-		"vscode": {
-			"extensions": [
-				// Note: The Julia extension is no needed here, as the Julia Feature will install it.
-				"tamasfe.even-better-toml"
-			]
-		}
-	}
+	// "customizations": {},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/src/julia/devcontainer-template.json
+++ b/src/julia/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
 	"id": "julia",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"name": "Julia",
 	"description": "Develop Julia applications.",
 	"documentationURL": "https://github.com/JuliaLang/devcontainer-templates/tree/main/src/julia",


### PR DESCRIPTION
Since now the julia Feature installs all extensions listed here (JuliaLang/devcontainer-features#14), that field is no longer needed.